### PR TITLE
Adding downloadOptions field to DATS.json

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -55,17 +55,20 @@
   "types": [
     {
       "information": {
-        "value": "Neuropsychological assessment"
+        "value": "Neuropsychological assessment",
+		"valueIRI": "http://uri.interlex.org/ilx_0485663"
       }
     },
     {
       "information": {
-        "value": "Cognitive assessment "
+        "value": "Cognitive assessment",
+		"valueIRI": "http://uri.interlex.org/ilx_0102339"
       }
     },
     {
       "information": {
-        "value": "Neuroimaging"
+        "value": "Neuroimaging",
+		"valueIRI": "http://uri.interlex.org/ilx_0741206"
       }
     },
     {

--- a/DATS.json
+++ b/DATS.json
@@ -496,6 +496,14 @@
         }
       ]
     },
+	{
+      "category": "downloadOptions",
+      "values": [
+        {
+          "value": "offsite"
+        }
+      ]
+    },
     {
       "category": "REB_statement",
       "values": [


### PR DESCRIPTION
This PR adds a downloadOptions field containing the value "offsite" to the DATS.json file, and also incorporates Interlex links for the "types" values.